### PR TITLE
Add webpack w/devserver to dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: serve
 serve:
-	webpack-dev-server --progress --colors --host 0.0.0.0 --inline --watch
+	npm start
 
 .PHONY: clean
 clean:

--- a/package.json
+++ b/package.json
@@ -10,6 +10,11 @@
     "babel-preset-react": "6.16.0",
     "react": "15.4.1",
     "react-dom": "15.4.1",
-    "react-tabs": "0.8.2"
+    "react-tabs": "0.8.2",
+    "webpack": "^1.14.0",
+    "webpack-dev-server": "^1.16.2"
+  },
+  "scripts": {
+    "start": "webpack-dev-server --progress --colors --host 0.0.0.0 --inline --watch"
   }
 }


### PR DESCRIPTION
Use npm scripts to prefer loading the local version of webpack over a
global install.